### PR TITLE
Call Python as `python3`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_custom_target(check
-    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/lit-runner.py ${CMAKE_CURRENT_SOURCE_DIR} -v -s --path=${CMAKE_BINARY_DIR}/bin
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/lit-runner.py ${CMAKE_CURRENT_SOURCE_DIR} -v -s --path=${CMAKE_BINARY_DIR}/bin
     DEPENDS compiler
     USES_TERMINAL)


### PR DESCRIPTION
Recent versions of macOS no longer ship with a `python` symlink, but instead require the user to call the interpreter as `python3`.