### PR TITLE
[Codegen] Do not emit `br` instructions if the insertion point is null

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -62,14 +62,16 @@ llvm::Value *Codegen::generateIfStmt(const ResolvedIfStmt &stmt) {
   trueBB->insertInto(function);
   builder.SetInsertPoint(trueBB);
   generateBlock(*stmt.trueBlock);
-  builder.CreateBr(exitBB);
+  if (builder.GetInsertBlock())
+    builder.CreateBr(exitBB);
 
   if (stmt.falseBlock) {
     elseBB->insertInto(function);
 
     builder.SetInsertPoint(elseBB);
     generateBlock(*stmt.falseBlock);
-    builder.CreateBr(exitBB);
+    if (builder.GetInsertBlock())
+      builder.CreateBr(exitBB);
   }
 
   exitBB->insertInto(function);
@@ -92,7 +94,8 @@ llvm::Value *Codegen::generateWhileStmt(const ResolvedWhileStmt &stmt) {
 
   builder.SetInsertPoint(body);
   generateBlock(*stmt.body);
-  builder.CreateBr(header);
+  if (builder.GetInsertBlock())
+    builder.CreateBr(header);
 
   builder.SetInsertPoint(exit);
   return nullptr;
@@ -460,7 +463,8 @@ void Codegen::generateFunctionBody(const ResolvedFunctionDecl &functionDecl) {
     generateBlock(*functionDecl.body);
 
   if (retBB->hasNPredecessorsOrMore(1)) {
-    builder.CreateBr(retBB);
+    if (builder.GetInsertBlock())
+      builder.CreateBr(retBB);
     retBB->insertInto(function);
     builder.SetInsertPoint(retBB);
   }

--- a/test/codegen/condition_empty_merge.yl
+++ b/test/codegen/condition_empty_merge.yl
@@ -22,7 +22,7 @@ fn main(): void {
 // CHECK-NEXT: if.true:                                          ; preds = %entry
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit:                                          ; preds = <null operand!>, %entry
+// CHECK-NEXT: if.exit:                                          ; preds =  %entry
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
 // CHECK-NEXT: return:                                           ; preds = %if.exit, %if.true

--- a/test/codegen/constexpr.yl
+++ b/test/codegen/constexpr.yl
@@ -14,7 +14,7 @@ fn constant(): number {
 // CHECK-NEXT:   store double 1.000000e+00, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   %0 = load double, double* %retval, align 8
 // CHECK-NEXT:   ret double %0
 // CHECK-NEXT: }
@@ -28,7 +28,7 @@ fn constant2(): number {
 // CHECK-NEXT:   store double 0.000000e+00, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   %0 = load double, double* %retval, align 8
 // CHECK-NEXT:   ret double %0
 // CHECK-NEXT: }

--- a/test/codegen/exercise/immutable_parameters.yl
+++ b/test/codegen/exercise/immutable_parameters.yl
@@ -18,7 +18,7 @@ fn foo(s: S, y: number): number {
 // CHECK-NEXT:   store double %3, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   %4 = load double, double* %retval, align 8
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }

--- a/test/codegen/exercise/return_struct.yl
+++ b/test/codegen/exercise/return_struct.yl
@@ -44,7 +44,7 @@ fn foo(var x: number): Small {
 // CHECK-NEXT:   br label %return
 
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -74,7 +74,7 @@ fn bar(): S {
 
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/test/codegen/exercise/struct_parameter.yl
+++ b/test/codegen/exercise/struct_parameter.yl
@@ -30,7 +30,7 @@ fn bar(var s: S): S {
 // CHECK-NEXT:   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %0, i8* align 8 %1, i64 16, i1 false)
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/test/codegen/exercise/structs_generated_first.yl
+++ b/test/codegen/exercise/structs_generated_first.yl
@@ -25,7 +25,7 @@ fn foo(s: S): S2 {
 
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 

--- a/test/codegen/multiple_return.yl
+++ b/test/codegen/multiple_return.yl
@@ -10,6 +10,6 @@ fn main(): void {
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds =  %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/test/codegen/multiple_return_if.yl
+++ b/test/codegen/multiple_return_if.yl
@@ -39,14 +39,14 @@ fn foo(var x: number): number {
 // CHECK-NEXT:   store double 1.000000e+01, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit:                                          ; preds = <null operand!>, %if.false
+// CHECK-NEXT: if.exit:                                          ; preds =  %if.false
 // CHECK-NEXT:   br label %if.exit5
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit5:                                         ; preds = %if.exit, <null operand!>
+// CHECK-NEXT: if.exit5:                                         ; preds = %if.exit
 // CHECK-NEXT:   store double 5.200000e+00, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %if.exit5, %if.true4, %if.true
+// CHECK-NEXT: return:                                           ; preds =  %if.exit5, %if.true4, %if.true
 // CHECK-NEXT:   %4 = load double, double* %retval, align 8
 // CHECK-NEXT:   ret double %4
 // CHECK-NEXT: }

--- a/test/codegen/multiple_return_while.yl
+++ b/test/codegen/multiple_return_while.yl
@@ -33,11 +33,11 @@ fn foo(var x: number): number {
 // CHECK-NEXT:   store double 3.000000e+00, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit:                                          ; preds = <null operand!>, %while.body
+// CHECK-NEXT: if.exit:                                          ; preds =  %while.body
 // CHECK-NEXT:   store double 5.000000e+00, double* %retval, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %while.exit, %if.exit, %if.true
+// CHECK-NEXT: return:                                           ; preds =  %while.exit, %if.exit, %if.true
 // CHECK-NEXT:   %7 = load double, double* %retval, align 8
 // CHECK-NEXT:   ret double %7
 

--- a/test/codegen/return.yl
+++ b/test/codegen/return.yl
@@ -9,7 +9,7 @@ fn noInsertPoint(): void {
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: return:                                           ; preds = <null operand!>, %entry
+// CHECK-NEXT: return:                                           ; preds = %entry
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -25,7 +25,7 @@ fn insertPointEmptyBlock(): void {
 // CHECK-NEXT: if.true:                                             ; preds = %entry
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit:                                            ; preds = <null operand!>, %entry
+// CHECK-NEXT: if.exit:                                            ; preds =  %entry
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
 // CHECK-NEXT: return:                                           ; preds = %if.exit, %if.true
@@ -41,7 +41,7 @@ fn insertPointEmptyBlock2(): void {
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   br label %while.cond
 // CHECK-NEXT: 
-// CHECK-NEXT: while.cond:                                        ; preds = <null operand!>, %entry
+// CHECK-NEXT: while.cond:                                        ; preds =  %entry
 // CHECK-NEXT:   br i1 true, label %while.body, label %while.exit
 // CHECK-NEXT: 
 // CHECK-NEXT: while.body:                                        ; preds = %while.cond
@@ -69,7 +69,7 @@ fn insertPointNonEmptyBlock(): void {
 // CHECK-NEXT: if.true:                                             ; preds = %entry
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
-// CHECK-NEXT: if.exit:                                            ; preds = <null operand!>, %entry
+// CHECK-NEXT: if.exit:                                            ; preds =  %entry
 // CHECK-NEXT:   store double 1.000000e+00, double* %x, align 8
 // CHECK-NEXT:   br label %return
 // CHECK-NEXT: 
@@ -89,7 +89,7 @@ fn insertPointNonEmptyBlock2(): void {
 // CHECK-NEXT:   %x = alloca double, align 8
 // CHECK-NEXT:   br label %while.cond
 // CHECK-NEXT: 
-// CHECK-NEXT: while.cond:                                        ; preds = <null operand!>, %entry
+// CHECK-NEXT: while.cond:                                        ; preds =  %entry
 // CHECK-NEXT:   br i1 true, label %while.body, label %while.exit
 // CHECK-NEXT: 
 // CHECK-NEXT: while.body:                                        ; preds = %while.cond

--- a/test/codegen/while_empty_exit.yl
+++ b/test/codegen/while_empty_exit.yl
@@ -11,7 +11,7 @@ fn foo(var x: number): void {
 // CHECK-NEXT:   store double %x, double* %x1, align 8
 // CHECK-NEXT:   br label %while.cond
 // CHECK-NEXT: 
-// CHECK-NEXT: while.cond:                                       ; preds = <null operand!>, %entry
+// CHECK-NEXT: while.cond:                                       ; preds =  %entry
 // CHECK-NEXT:   %0 = load double, double* %x1, align 8
 // CHECK-NEXT:   %1 = fcmp ogt double %0, 1.000000e+00
 // CHECK-NEXT:   %to.double = uitofp i1 %1 to double


### PR DESCRIPTION
When a block contains a `return` statement, we should not add another `br` instruction at its end, as it's already terminated. This was previously achieved by setting the insertion point to null when encountering a `ResolvedReturnStmt`.

Unfortunately, this "orphan" `br` is still considered a predecessor of the target basic block (which is shown by `preds = <null operand!>` in the IR). If using a debug build of LLVM, this triggers a "Uses remain when a value is destroyed!" assertion in `~BasicBlock`, as the `br` is never destroyed.